### PR TITLE
Fix protocol and host always present when extracting new links

### DIFF
--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -50,7 +50,7 @@ export default class Crawler {
       const urlAttribute = tagAttributeMap[tagName]
       Array.from(document.querySelectorAll(`${tagName}[${urlAttribute}]`)).forEach(element => {
         const { protocol, host, path } = url.parse(element[urlAttribute])
-        if (protocol || host) return
+        if (protocol !== this.protocol || host !== this.host) return
         const relativePath = url.resolve(currentPath, path)
         if (!this.processed[relativePath]) this.paths.push(relativePath)
       })


### PR DESCRIPTION
Commit 0ea91b0f021 replaced regex matching of URLs with DOM parsing, introducing a bug in that HTMLAnchorElement#href and HTMLIFrameElement#src always return the whole URL, thus when parsing the returned URL, protocol and host will never be blank. This stops the crawler from following new URLs.

This fix compares the parsed protocol and host with the crawler's original protocol and host in order to determine whether to follow the extracted URL or not.