### PR TITLE
Fix non-existing directory error when writing files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "prepublish": "rm -rf lib/* && npm run build"
   },
   "dependencies": {
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0",
     "jsdom": "^9.4.5",
-    "pushstate-server": "^1.12.0"
+    "mkdirp": "^0.5.1",
+    "pushstate-server": "^1.12.0",
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/Writer.js
+++ b/src/Writer.js
@@ -1,6 +1,7 @@
 /* Simple wrapper around fs so I can concentrate on what's going on */
 import fs from 'fs'
 import path from 'path'
+import { sync as mkDirPSync } from 'mkdirp'
 
 export default class Writer {
   constructor(baseDir) {
@@ -18,6 +19,8 @@ export default class Writer {
 
   write(filename, content) {
     const newPath = path.join(this.baseDir, filename)
+    const dirName = path.dirname(newPath)
+    mkDirPSync(dirName)
     fs.writeFileSync(newPath, content)
   }
 }


### PR DESCRIPTION
Given `/base/path/` dir exists and `/base/path/sub/` doesn't, then the following fails:

```js
(new Writer('/base/path')).write('sub/foo.html', 'foo')
//=> Error: ENOENT: no such file or directory, open '/base/path/sub/foo.html'
```

This happens, e.g., when there's an `<a href="/sub/foo">foo</a>` in the HTML.

This fix uses the mkdirp package to create missing parent directories before writing the file.