### PR TITLE
attempt to read paths from package.json

### DIFF
--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -3,6 +3,10 @@
 import url from 'url'
 import snapshot from './snapshot'
 import jsdom from 'jsdom'
+import path from 'path'
+
+const pkg = require(path.join(process.cwd(), 'package.json'));
+const paths = pkg.reactSnapshot.paths
 
 export default class Crawler {
   constructor(baseUrl) {
@@ -10,7 +14,7 @@ export default class Crawler {
     const { protocol, host, path } = url.parse(baseUrl)
     this.protocol = protocol
     this.host = host
-    this.paths = [path]
+    this.paths = [path,...paths]
     this.processed = {}
   }
 


### PR DESCRIPTION
Hi,

I gave a shot at #11, modifying Crawler so that it reads package.json to find additional paths to crawl. For instance, given
```
/* package.json */
{
  ...,
  "reactSnapshot": {
    "paths":[
      "/other-path"
    ]
  },
...
}
``` 
react-snapshot will crawl both "/" and "/other-path".

Hope this helps,
Alain