### PR TITLE
Crashes on links that only have # as value for href

### DIFF
--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -49,7 +49,9 @@ export default class Crawler {
     Object.keys(tagAttributeMap).forEach(tagName => {
       const urlAttribute = tagAttributeMap[tagName]
       Array.from(document.querySelectorAll(`${tagName}[${urlAttribute}]`)).forEach(element => {
-        const { protocol, host, path } = url.parse(element.getAttribute(urlAttribute))
+        const attrValue = element.getAttribute(urlAttribute);
+        if (attrValue === '#') return
+        const { protocol, host, path } = url.parse(attrValue)
         if (protocol || host) return
         const relativePath = url.resolve(currentPath, path)
         if (!this.processed[relativePath]) this.paths.push(relativePath)


### PR DESCRIPTION
Basically this:
```js
<a href="#">Crash it!</a>
```
will crash the build:
```
Pushstate server started on port 2999

🕷   Starting crawling http://localhost:2999
TypeError: Parameter "url" must be a string, not object
    at Url.parse (url.js:87:11)
    at urlParse (url.js:81:5)
    at Url.resolve (url.js:641:29)
    at Object.urlResolve [as resolve] (url.js:637:40)
    at /app/node_modules/react-snapshot/lib/Crawler.js:96:44
    at Array.forEach (native)
    at /app/node_modules/react-snapshot/lib/Crawler.js:88:83
    at Array.forEach (native)
    at Crawler.extractNewLinks (/app/node_modules/react-snapshot/lib/Crawler.js:86:36)
    at /app/node_modules/react-snapshot/lib/Crawler.js:68:15
```

This PR just makes the Crawler ignore it and continue crawling.