### PR TITLE
Skip null paths created by hash routing

### DIFF
--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -50,7 +50,7 @@ export default class Crawler {
       const urlAttribute = tagAttributeMap[tagName]
       Array.from(document.querySelectorAll(`${tagName}[${urlAttribute}]`)).forEach(element => {
         const { protocol, host, path } = url.parse(element.getAttribute(urlAttribute))
-        if (protocol || host) return
+        if (protocol || host || path===null) return;
         const relativePath = url.resolve(currentPath, path)
         if (!this.processed[relativePath]) this.paths.push(relativePath)
       })


### PR DESCRIPTION
Similar to #13 but with newer version of `react-snapshot`. Prevents crashing due to hash routing.