### PR TITLE
Handle publicPath when specified (#16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "prepublish": "rm -rf lib/* && npm run build"
   },
   "dependencies": {
+    "express": "^4.15.2",
     "jsdom": "^9.4.5",
     "mkdirp": "^0.5.1",
-    "pushstate-server": "^1.12.0",
     "react": "^15.3.0",
     "react-dom": "^15.3.0"
   },

--- a/src/Server.js
+++ b/src/Server.js
@@ -1,18 +1,25 @@
-/* Spin up a simple pushstate server */
-import pushstate from 'pushstate-server'
+/* Spin up a simple express server */
+import express from 'express'
 
 export default class Server {
-  constructor(baseDir, file, port) {
-    this.start = () => {
-      return new Promise((resolve, reject) => {
-        this.instance = pushstate.start({
-          port,
-          directories: [baseDir],
-          file
-        })
-        setTimeout(resolve, 1000) /* fuckn node apis how can you tell when a connect server is ready to accept connections when you dont have the internet because you're on a plane fkn */
+  constructor(baseDir, publicPath, port) {
+    const app = express()
+
+    app.use(publicPath, express.static(baseDir, { index: '200.html' }))
+
+    this.start = this.start.bind(this, app, port)
+  }
+
+  start(app, port) {
+    return new Promise((resolve, reject) => {
+      this.instance = app.listen(port, (err) => {
+        if (err) {
+          return reject(err)
+        }
+
+        resolve()
       })
-    }
+    })
   }
 
   stop() {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,19 +1,25 @@
 import path from 'path'
+import fs from 'fs'
+import url from 'url'
 import Server from './Server'
 import Crawler from './Crawler'
 import Writer from './Writer'
+
+const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json')))
+const publicPath = pkg.homepage ? url.parse(pkg.homepage).pathname : '/'
 
 export default () => {
   const baseDir = path.resolve('./build')
   const writer = new Writer(baseDir)
   writer.move('index.html', '200.html')
 
-  const server = new Server(baseDir, '/200.html', 2999)
+  const server = new Server(baseDir, publicPath, 2999)
   server.start().then(() => {
-
-    const crawler = new Crawler("http://localhost:2999")
+    const crawler = new Crawler(`http://localhost:2999${publicPath}`)
     return crawler.crawl(({ path, html }) => {
-      const filename = `${path}${path.endsWith('/') ? 'index' : ''}.html`
+      const filename = path === publicPath ?
+        'index.html' :
+        `${path}${path.endsWith('/') ? 'index' : ''}.html`
       console.log(`✏️   Saving ${path} as ${filename}`)
       writer.write(filename, html)
     })


### PR DESCRIPTION
See #16.

It reads the `homepage` field in `package.json` if specified, and perform the rest work.

I replaced `pushstate-server` with `express` to open the server with public path, as I couldn't find any public api of `pushstate-server` to do that.

It works for me, but not yet test on a multi-url app.