### PR TITLE
Add option to exclude paths, fix crash on missing reactSnapshot section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ The snapshots still have the normal JS bundle included, so once that downloads t
 
 This calls `ReactDOM.render` in development and `ReactDOMServer.renderToString` when prerendering. If I can make this invisible I will but I can't think how at the moment.
 
+## Options
+You can specify additional paths as entry points for crawling that would otherwise not be found. It's also possible to exclude particular paths from crawling. Simply add a section called `"reactSnapshot"` to your package.json
+```
+  "reactSnapshot": {
+    "paths": [
+      "/crawl_me_too"
+    ],
+    "exclude": [
+      "/crawl_me_too/but_exclude_me"
+    ]
+  }
+```
+
 ## The Demo
 
 Check out [create-react-app-snapshot.surge.sh](https://create-react-app-snapshot.surge.sh) for a live version or [geelen/create-react-app-snapshot](https://github.com/geelen/create-react-app-snapshot) for how it was built, starting from [create-react-app](https://github.com/facebookincubator/create-react-app)'s awesome baseline. No ejecting necessary, either.

--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -6,7 +6,8 @@ import jsdom from 'jsdom'
 import path from 'path'
 
 const pkg = require(path.join(process.cwd(), 'package.json'));
-const paths = pkg.reactSnapshot.paths
+const paths = pkg.reactSnapshot && pkg.reactSnapshot.paths || []
+const exclude = pkg.reactSnapshot && pkg.reactSnapshot.exclude || []
 
 export default class Crawler {
   constructor(baseUrl) {
@@ -57,7 +58,7 @@ export default class Crawler {
         const { protocol, host, path } = url.parse(element.getAttribute(urlAttribute))
         if (protocol || host || path===null) return;
         const relativePath = url.resolve(currentPath, path)
-        if (!this.processed[relativePath]) this.paths.push(relativePath)
+        if (!this.processed[relativePath] && exclude.indexOf(relativePath) < 0) this.paths.push(relativePath)
       })
     })
   }


### PR DESCRIPTION
It can be helpful to deliberately exclude some paths from the crawling process. Therefore I added an option to do so via package.json. It also fixes the crash if you don't have a reactSnapshot section in your package.json at all (regression from 05628b4cf9cd5ccca18b248dae797d67ec1a7e5a) and adds documentation for those features.