### PR TITLE
fix: fix rendering of react-router routes with express

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -6,6 +6,9 @@ export default class Server {
     const app = express()
 
     app.use(publicPath, express.static(baseDir, { index: '200.html' }))
+    app.use('/**', (req, res) => {
+      res.sendFile('200.html', {root: baseDir})
+    })
 
     this.start = this.start.bind(this, app, port)
   }


### PR DESCRIPTION
There has been a regression when having switched to node express. react-router routes would not work anymore, resulting in outputting "404 cannot get /foo/bar" for every route except '/'
To get react-router to work, express needs to be configured to deliver the index.html for every unknown path in order to let react handle the routing.