### PR TITLE
Fixed crawling of projects with publicPath != "/"

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -15,12 +15,14 @@ export default class Server {
     })
 
     // Yes I just copied most of this from react-scripts ¯\_(ツ)_/¯
-    app.use(historyApiFallback({
-      index: '/200.html',
-      disableDotRule: true,
-      htmlAcceptHeaders: ['text/html'],
-    }))
-    app.use(publicPath, express.static(baseDir, { index: '200.html' }))
+    app.use(publicPath,
+      historyApiFallback({
+        index: '/200.html',
+        disableDotRule: true,
+        htmlAcceptHeaders: ['text/html'],
+      }),
+      express.static(baseDir, { index: '200.html' })
+    )
 
     if (proxy) {
       if (typeof proxy !== "string") throw new Error("Only string proxies are implemented currently.")

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,7 +26,7 @@ export default () => {
 
   const server = new Server(buildDir, basename, 0, pkg.proxy)
   server.start().then(() => {
-    const crawler = new Crawler(`http://localhost:${server.port()}/`, snapshotDelay, options)
+    const crawler = new Crawler(`http://localhost:${server.port()}${basename}`, snapshotDelay, options)
     return crawler.crawl(({ urlPath, html }) => {
       if (!urlPath.startsWith(basename)) {
         console.log(`❗ Refusing to crawl ${urlPath} because it is outside of the ${basename} sub-folder`)


### PR DESCRIPTION
As _connect-history-api-fallback_ would try to serve _/200.html_ file for any non-found request, it would just fail and return a 404 page as pages generated with _publicPath_ other than _"/"_ would have the _200.html_ file within the _publicPath_ subdirectory, not root. This commit wraps the _historyApiFallback_ inside the _publicPath_ route.

There is an additional optional step that I didn't implement here: 
Switching the order of _express.static()_ and the _historyApiFallback_. 
Currently, it tries to serve the _200.html_ file first (if there is a GET request for text/html). Only after that fails (for non-html requests), files out of the static dir are served. This might be the wrong order as some static html-files (inside of the public folder) will never get served. Best would be to reorder those 2 to first serve existing static files, and only then fall back to the _200.html_ file