### PR TITLE
V2 API — Async snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Snapshot
 
-A zero-configuration static pre-renderer for React apps. Starting by targeting Create React App (because it's great)
+A zero-configuration static pre-renderer for React apps, built for Create React App (because it's great)
 
 ## The Premise
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "react-snapshot": "./bin/react-snapshot.js"
   },
   "scripts": {
-    "build": "babel --out-dir lib src",
-    "build:watch": "npm run build -- --watch",
+    "babel": "babel --out-dir lib src",
+    "build": "NODE_ENV=production npm run babel",
+    "build:watch": "NODE_ENV=development npm run babel -- --watch",
     "prepublish": "rm -rf lib/* && npm run build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-snapshot",
-  "version": "2.0.0",
+  "version": "2.0.0-0",
   "description": "",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-snapshot",
-  "version": "1.1.0",
+  "version": "1.1.1-0",
   "description": "",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-snapshot",
-  "version": "1.1.1-0",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "bin": {

--- a/src/Server.js
+++ b/src/Server.js
@@ -54,6 +54,6 @@ export default class Server {
   }
 
   stop() {
-    //this.instance.close()
+    this.instance.close()
   }
 }

--- a/src/Server.js
+++ b/src/Server.js
@@ -54,6 +54,6 @@ export default class Server {
   }
 
   stop() {
-    this.instance.close()
+    //this.instance.close()
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,8 @@ export default () => {
   const writer = new Writer(buildDir)
   writer.move('index.html', '200.html')
 
-  const server = new Server(buildDir, basename, 0, pkg.proxy)
+  const proxy = process.env.REACT_SNAPSHOT_PROXY || pkg.proxy
+  const server = new Server(buildDir, basename, 0, proxy)
   server.start().then(() => {
     const crawler = new Crawler(`http://localhost:${server.port()}/`, snapshotDelay, options)
     return crawler.crawl(({ urlPath, html }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import ReactDOM from 'react-dom';
+import React from 'react'
+import ReactDOM from 'react-dom'
 
 export const IS_REACT_SNAPSHOT = navigator.userAgent.match(/Node\.js/i) && window && window.react_snapshot_render
 
@@ -15,19 +16,76 @@ export const render = (rootComponent, domElement) => {
   }
 }
 
-export const async = func => {
+export const snapshot = func => {
   const i = count++
   const existing = state.data[i]
   if (existing) {
-    console.log("SHORT CIRCUIT!")
-    return { then: x => x(...existing) }
+    const { success, failure } = existing
+    /* This mimics a Promise API but is entirely synchronous */
+    return {
+      then(resolve, reject) {
+        if (typeof success !== 'undefined') resolve(success)
+        else if (reject && typeof failure !== 'undefined') reject(failure)
+      },
+      catch(reject) {
+        if (typeof failure !== 'undefined') reject(success)
+      }
+    }
   } else {
     if (!IS_REACT_SNAPSHOT) return func()
-    const promise = func().then((...response) => new Promise(resolve => {
-      state.data[i] = response
-      resolve(...response)
-    }))
+    const promise = func().then(
+      success => {
+        state.data[i] = { success }
+        return success
+      },
+      failure => {
+        state.data[i] = { failure }
+        return Promise.reject(failure)
+      }
+    )
     state.requests.push(promise)
     return promise
+  }
+}
+
+export const Snapshot = (prop_defs) => {
+  const prop_names = Object.keys(prop_defs)
+  if (typeof prop_defs !== "object" ||
+    prop_names.some(k => typeof prop_defs[k] !== 'function')
+  ) throw new Error("Snapshot requires an object of type { propName: () => Promise }.")
+  console.log(prop_defs)
+
+  const hoc = (Component, render_without_data) => {
+    class SnapshotComponent extends React.Component {
+      constructor() {
+        super()
+        this.state = { loaded_all: false, async_props: null }
+      }
+
+      componentWillMount() {
+        snapshot(() =>
+          Promise.all(prop_names.map(prop_name => prop_defs[prop_name](this.props)))
+        ).then(responses => {
+          const new_state = {}
+          prop_names.forEach((prop_name, i) => new_state[prop_name] = responses[i])
+          this.setState({ async_props: new_state, loaded_all: true })
+        })
+      }
+
+      render() {
+        if (!this.state.loaded_all && !render_without_data) return null
+        const props = Object.assign({},
+          this.props,
+          this.state.async_props
+        )
+        return React.createElement(Component, props)
+      }
+    }
+    SnapshotComponent.displayName = `Snapshot(${Component.displayName || Component.name})`
+    return SnapshotComponent
+  }
+  return {
+    thenRender: Component => hoc(Component, false),
+    rendering: Component => hoc(Component, true)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,30 @@
 import ReactDOM from 'react-dom';
-import ReactDOMServer from 'react-dom/server';
+
+const state = {
+  requests: [],
+  data: window.react_snapshot_state || {},
+}
+let count = 0
 
 export const render = (rootComponent, domElement) => {
-  if (navigator.userAgent.match(/Node\.js/i) && window && window.reactSnapshotRender) {
-    domElement.innerHTML = ReactDOMServer.renderToString(rootComponent)
-    window.reactSnapshotRender()
+  ReactDOM.render(rootComponent, domElement)
+  if (navigator.userAgent.match(/Node\.js/i) && window && window.react_snapshot_render) {
+    window.react_snapshot_render(domElement, state)
+  }
+}
+
+export const async = func => {
+  const i = count++
+  const existing = state.data[i]
+  if (existing) {
+    console.log("SHORT CIRCUIT!")
+    return { then: x => x(...existing) }
   } else {
-    ReactDOM.render(rootComponent, domElement)
+    const promise = func().then((...response) => new Promise(resolve => {
+      state.data[i] = response
+      resolve(...response)
+    }))
+    state.requests.push(promise)
+    return promise
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import ReactDOM from 'react-dom';
 
+export const IS_REACT_SNAPSHOT = navigator.userAgent.match(/Node\.js/i) && window && window.react_snapshot_render
+
 const state = {
   requests: [],
   data: window.react_snapshot_state || {},
@@ -8,7 +10,7 @@ let count = 0
 
 export const render = (rootComponent, domElement) => {
   ReactDOM.render(rootComponent, domElement)
-  if (navigator.userAgent.match(/Node\.js/i) && window && window.react_snapshot_render) {
+  if (IS_REACT_SNAPSHOT) {
     window.react_snapshot_render(domElement, state)
   }
 }
@@ -20,6 +22,7 @@ export const async = func => {
     console.log("SHORT CIRCUIT!")
     return { then: x => x(...existing) }
   } else {
+    if (!IS_REACT_SNAPSHOT) return func()
     const promise = func().then((...response) => new Promise(resolve => {
       state.data[i] = response
       resolve(...response)

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -1,10 +1,11 @@
 /* Wraps a jsdom call and returns the full page */
 
 import jsdom from 'jsdom'
+import * as ReactMarkupChecksum from 'react-dom/lib/ReactMarkupChecksum'
 
 export default (protocol, host, path, delay) => {
   return new Promise((resolve, reject) => {
-    let reactSnapshotRenderCalled = false
+    let render_called = false
     jsdom.env({
       url: `${protocol}//${host}${path}`,
       headers: { Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8" },
@@ -23,17 +24,32 @@ export default (protocol, host, path, delay) => {
       virtualConsole: jsdom.createVirtualConsole().sendTo(console),
       created: (err, window) => {
         if (err) reject(err)
-        window.reactSnapshotRender = () => {
-          reactSnapshotRenderCalled = true
-          setTimeout(() => {
-            resolve(window)
-          }, delay)
+        window.react_snapshot_render = (element, state) => {
+          render_called = { element, state }
         }
       },
       done: (err, window) => {
-        if (!reactSnapshotRenderCalled) {
-          reject("'render' from react-snapshot was never called. Did you replace the call to ReactDOM.render()?")
+        if (!render_called) {
+          return reject("'render' from react-snapshot was never called. Did you replace the call to ReactDOM.render()?")
         }
+
+        const { element, state } = render_called
+
+        const next = () => {
+          const shift = state.requests.shift()
+          return shift && shift.then(next)
+        }
+        /* Wait a short while, then wait for all requests, then serialise */
+        new Promise(res => setTimeout(res, delay))
+          .then(next)
+          .then(() => {
+            console.log(state.data)
+            element.outerHTML = ReactMarkupChecksum.addChecksumToMarkup(element.outerHTML)
+            window.document.body.insertAdjacentHTML('afterBegin', `
+              <script>window.react_snapshot_state = ${JSON.stringify(state.data)};</script>
+            `)
+            resolve(window)
+          })
       }
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,6 +196,14 @@ babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-helper-builder-react-jsx@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz#0ad7917e33c8d751e646daca4e77cc19377d2cbc"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+    esutils "^2.0.0"
+
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
@@ -261,6 +269,16 @@ babel-helper-regex@^6.24.1:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
@@ -295,9 +313,62 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-node@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.0.2.tgz#adb5bc8f48a89311540395ae9f0cc3ed4b10bb2e"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
+babel-plugin-syntax-dynamic-import@6.18.0, babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
+babel-plugin-syntax-flow@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
+babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-async-to-generator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -311,7 +382,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.24.1:
+babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz#76c295dc3a4741b1665adfd3167215dcff32a576"
   dependencies:
@@ -321,7 +392,7 @@ babel-plugin-transform-es2015-block-scoping@^6.24.1:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-classes@^6.24.1:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -335,33 +406,33 @@ babel-plugin-transform-es2015-classes@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.24.1:
+babel-plugin-transform-es2015-computed-properties@^6.22.0, babel-plugin-transform-es2015-computed-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.22.0:
+babel-plugin-transform-es2015-destructuring@^6.22.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-duplicate-keys@^6.24.1:
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0, babel-plugin-transform-es2015-duplicate-keys@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-for-of@^6.22.0:
+babel-plugin-transform-es2015-for-of@^6.22.0, babel-plugin-transform-es2015-for-of@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-function-name@^6.24.1:
+babel-plugin-transform-es2015-function-name@^6.22.0, babel-plugin-transform-es2015-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
   dependencies:
@@ -375,7 +446,7 @@ babel-plugin-transform-es2015-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-modules-amd@^6.24.1:
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
   dependencies:
@@ -383,7 +454,7 @@ babel-plugin-transform-es2015-modules-amd@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz#d3e310b40ef664a36622200097c6d440298f2bfe"
   dependencies:
@@ -392,7 +463,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
     babel-template "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0, babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
   dependencies:
@@ -400,7 +471,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-umd@^6.24.1:
+babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015-modules-umd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
   dependencies:
@@ -408,14 +479,14 @@ babel-plugin-transform-es2015-modules-umd@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-object-super@^6.24.1:
+babel-plugin-transform-es2015-object-super@^6.22.0, babel-plugin-transform-es2015-object-super@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
   dependencies:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.24.1:
+babel-plugin-transform-es2015-parameters@^6.23.0, babel-plugin-transform-es2015-parameters@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -426,7 +497,7 @@ babel-plugin-transform-es2015-parameters@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.24.1:
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0, babel-plugin-transform-es2015-shorthand-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
@@ -439,7 +510,7 @@ babel-plugin-transform-es2015-spread@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-sticky-regex@^6.24.1:
+babel-plugin-transform-es2015-sticky-regex@^6.22.0, babel-plugin-transform-es2015-sticky-regex@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
   dependencies:
@@ -453,13 +524,13 @@ babel-plugin-transform-es2015-template-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.22.0:
+babel-plugin-transform-es2015-typeof-symbol@^6.22.0, babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-unicode-regex@^6.24.1:
+babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es2015-unicode-regex@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
   dependencies:
@@ -467,7 +538,7 @@ babel-plugin-transform-es2015-unicode-regex@^6.24.1:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
-babel-plugin-transform-exponentiation-operator@^6.24.1:
+babel-plugin-transform-exponentiation-operator@^6.22.0, babel-plugin-transform-exponentiation-operator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
   dependencies:
@@ -475,11 +546,65 @@ babel-plugin-transform-exponentiation-operator@^6.24.1:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@^6.24.1:
+babel-plugin-transform-flow-strip-types@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
+  dependencies:
+    babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-constant-elements@6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz#2f119bf4d2cdd45eb9baaae574053c604f6147dd"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-display-name@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz#4398910c358441dc4cef18787264d0412ed36b37"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-self@6.22.0, babel-plugin-transform-react-jsx-self@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx-source@6.22.0, babel-plugin-transform-react-jsx-source@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
+  dependencies:
+    babel-helper-builder-react-jsx "^6.24.1"
+    babel-plugin-syntax-jsx "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-regenerator@6.24.1, babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
   dependencies:
     regenerator-transform "0.9.11"
+
+babel-plugin-transform-runtime@6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
@@ -495,6 +620,40 @@ babel-polyfill@^6.23.0:
     babel-runtime "^6.22.0"
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-preset-env@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.4.0.tgz#c8e02a3bcc7792f23cded68e0355b9d4c28f0f7a"
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^1.4.0"
+    invariant "^2.2.2"
 
 babel-preset-es2015@^6.13.2:
   version "6.24.1"
@@ -530,6 +689,40 @@ babel-preset-es2016@^6.11.3:
   resolved "https://registry.yarnpkg.com/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz#f900bf93e2ebc0d276df9b8ab59724ebfd959f8b"
   dependencies:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
+
+babel-preset-flow@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+
+babel-preset-react-app@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-3.0.0.tgz#f4505092f8bba0f0147c764dc72055fe46ac1416"
+  dependencies:
+    babel-plugin-dynamic-import-node "1.0.2"
+    babel-plugin-syntax-dynamic-import "6.18.0"
+    babel-plugin-transform-class-properties "6.24.1"
+    babel-plugin-transform-object-rest-spread "6.23.0"
+    babel-plugin-transform-react-constant-elements "6.23.0"
+    babel-plugin-transform-react-jsx "6.24.1"
+    babel-plugin-transform-react-jsx-self "6.22.0"
+    babel-plugin-transform-react-jsx-source "6.22.0"
+    babel-plugin-transform-regenerator "6.24.1"
+    babel-plugin-transform-runtime "6.23.0"
+    babel-preset-env "1.4.0"
+    babel-preset-react "6.24.1"
+
+babel-preset-react@6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
+  dependencies:
+    babel-plugin-syntax-jsx "^6.3.13"
+    babel-plugin-transform-react-display-name "^6.23.0"
+    babel-plugin-transform-react-jsx "^6.24.1"
+    babel-plugin-transform-react-jsx-self "^6.22.0"
+    babel-plugin-transform-react-jsx-source "^6.22.0"
+    babel-preset-flow "^6.23.0"
 
 babel-register@^6.24.1:
   version "6.24.1"
@@ -628,9 +821,20 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browserslist@^1.4.0:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  dependencies:
+    caniuse-db "^1.0.30000639"
+    electron-to-chromium "^1.2.7"
+
 buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+
+caniuse-db@^1.0.30000639:
+  version "1.0.30000676"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000676.tgz#82ea578237637c8ff34a28acaade373b624c4ea8"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -803,6 +1007,10 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+electron-to-chromium@^1.2.7:
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz#1b3a5eace6e087bb5e257a100b0cbfe81b2891fc"
+
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
@@ -840,7 +1048,7 @@ estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-esutils@^2.0.2:
+esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -1173,7 +1381,7 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-invariant@^2.2.0:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:


### PR DESCRIPTION
Hey friends! I have some FANCY NEW IDEAS™ about this library but would love some REAL HUMAN FEEDBACK™ from smart, good-looking people such as yourself.

Some backstory: React-snapshot started life as basically a zero-configuration static site generator, where you have a file system full of 'pages' or 'posts' or something, that it then gets crawled and generates all the static pages for. What I wanted was a version of Gatsby or Phenomic or static-site-generator-webpack-plugin or static-react except it was a three-line change from default Create React App install:

```diff
package.json:

- "build": "react-scripts build"
+ "build": "react-scripts build && react-snapshot"

index.js:

- import ReactDOM from 'react-dom'
+ import { render } from 'react-snapshot'
- ReactDOM.render(
+ render(
```

It worked pretty well, and after I fixed a couple of silly bugs that had been sitting around for several months it works even better.

However, I pretty quickly wanted to try this out on a non-static site, to see if there was a way to have the crawler snapshot a DB-driven application. This makes it a lot more similar to something like next.js, but again, I wanted the minimal possible changes from a vanilla CRA.

This is what I've been able to build so far:

```diff
+ import { snapshot } from 'react-snapshot'

class Home extends React.Component {
  state = { quotes: null }

  componentWillMount() {
+   snapshot(() => (
      fetch('/api/quotes')
        .then(response => response.json())
+   ))
    .then(quotes => {
      this.setState({ quotes })
    })
  }

  render() {
    const { quotes } = this.state
    return (
      <div className="Quotes">
        {
          quotes && quotes.map((quote, i) => <Quote key={i} quote={quote}/>)
        }
      </div>
    )
  }
}
```

During the initial app rendering at build time (using JSDOM), if any `snapshot` methods are called, we start tracking it, cache the result, then serialise the result alongside the static HTML that we produce. When the app gets booted on the client, that same `snapshot` method short-circuits, immediately calling the `.then` and the state gets populated _before the render method is called_. This means there's no flash, the checksum matches, and everything is JUST GREAT™.

I have to do some tricks behind the scenes to make this work—I'm not using a Promise internally because they're always asynchronous i.e. the render method would run with an empty state, then on the next tick (potentially after a paint) the `setState` call would fix things up. I simply stub about the `then` and `catch` methods to call them _immediately_. As far as I can tell, this will work JUST FINE™.

Basically, any async part of your app that gets data and returns a promise can be wrapped in a `snapshot` call and it'll get cached. Since there's no way to know which `snapshot` call is which, I simply assume that it'll happen in precisely the same order during build in JSDOM as in the client. This assumption also _seems_ ok for the moment, but again there might be a case where it breaks down. For now though, things JUST WORK™.

I also expanded the API a little bit because these kinds of data-fetching components are super common and Next.JS has it's trendy `async getInitialProps` extension (which is too heavy for my liking) so I made like a hipster and carved out an artisanal HOC for my new library:

```js
const Home = ({ quotes }) => (
  <div className="Quotes">
    {
      quotes && quotes.map((quote, i) => <Quote key={i} quote={quote}/>)
    }
  </div>
)

export default Snapshot({
  quotes: () => fetch('/api/quotes').then(resp => resp.json())
}).rendering(Home)
```

That `rendering` bit means _"render `Home` even if I have no data"_. The alternative is `thenRender`, which will wait until all the promises have been resolved.

There's also another neat thing I just added while I was writing this PR where, if there's a chance your data will change more often than you'll deploy new snapshots, you might want to run the async code again and re-render when you've got the data hot & fresh off the API. That's easy:

```diff
  componentWillMount() {
-   snapshot(() => (
+   snapshot.repeat(() => (
      fetch('/api/quotes')
        .then(response => response.json())
    ))
    .then(quotes => {
      this.setState({ quotes })
    })
  }
```

```diff
- export default Snapshot({
+ export default Snapshot.repeat({
    quotes: () => fetch('/api/quotes').then(resp => resp.json())
  }).rendering(Home)
```

Basically, I don't want to try to cover the whole gamut of server-rendering use-cases, I'm just trying to solve the common use cases in the smallest amount of code possible. I want people to build more stuff in React using CRA but then have this super easy transition to hosting pre-rendered, critical-CSS-inlined, cached-on-a-nearby-CDN, reddit-frontpage-proof site.

What'd I'd like from you, smart & good-looking human, is to let me know what you think of the idea & implementation. Is the magic-synchronous-Promise & assumption of deterministic order too magic? Are methods like `rendering` and `repeat` worse than simple config objects? Or, and maybe this is the most important one, can you see a use case where this approach would break down so horribly that I shouldn't ship the API in its current state.

Just FYI, I do have this running on a demo site in production: http://react-snapshot-demo.pithy.af/. During deployment, the current API is crawled and snapshots for each page are taken. You can click around the whole site without JS, but if you have it on, it works like a normal React app, making API requests as it needs to. The homepage is using `Snapshot.repeat` but all other pages should not make a single API request if you reload the page.

If you want to try it out on your own site, it's published as `react-snapshot@next`. Hope it works! ❤️ 