### PR TITLE
Add snapshotState for any JSON serializable data

### DIFF
--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -35,6 +35,12 @@ export default class Crawler {
       this.processed[urlPath] = true
     }
     return snapshot(this.protocol, this.host, urlPath, this.snapshotDelay).then(window => {
+      if (window.snapshotState != null) {
+        const stateJSON = JSON.stringify(window.snapshotState)
+        const script = window.document.createElement('script')
+        script.innerHTML = `window.snapshotState = JSON.parse('${stateJSON}');`
+        window.document.head.appendChild(script)
+      }
       const html = jsdom.serializeDocument(window.document)
       this.extractNewLinks(window, urlPath)
       this.handler({ urlPath, html })


### PR DESCRIPTION
Could be used with Redux for instance:

```js
const store = redux.createStore(reducer, window.snapshotState || initialState)

store.subscribe(() => {
  window.snapshotState = store.getState()
})
```

- Can add some documentation if you are interested. 

- It might be better to depend on [js-stringify](https://github.com/pugjs/js-stringify) instead of JSON, what do you think?