### PR TITLE
Upgrade dependency with vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "connect-history-api-fallback": "^1.3.0",
     "express": "^4.15.2",
     "glob-to-regexp": "^0.3.0",
-    "http-proxy-middleware": "^0.17.4",
+    "http-proxy-middleware": "^0.20.0",
     "jsdom": "^9.4.5",
     "mkdirp": "^0.5.1",
     "safe-commander": "^2.11.1"


### PR DESCRIPTION
http-proxy-middleware's depenedency on braces introduces a minor
vulnerability that is flagged by npm audit. Since this is a dependency as opposed to a dev depenedency, it introduces that npm audit warning in any codebase using react-snapshot.

Upgrading the http-proxy-middleware package resolves this.